### PR TITLE
Actually use the local source variable

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -6,7 +6,7 @@ AddEventHandler('redemrp_banking:withdraw', function(amount)
 	local _amount = tonumber(amount)
 	--print(amount)
 	if amount ~= nil then
-    TriggerEvent('redemrp:getPlayerFromId', source, function(user)
+    TriggerEvent('redemrp:getPlayerFromId', _source, function(user)
         local identifier = user.getIdentifier()
         local charid = user.getSessionVar("charid")		
         TriggerEvent("getBankMoney", identifier, charid, function(call)
@@ -31,7 +31,7 @@ AddEventHandler('redemrp_banking:deposit', function(amount)
     local _source = source
 	local _amount = tonumber(amount)
 	if amount ~= nil then
-    TriggerEvent('redemrp:getPlayerFromId', source, function(user)
+    TriggerEvent('redemrp:getPlayerFromId', _source, function(user)
         local currentMoney = user.getMoney()
         if _amount == nil or _amount <= 0 or _amount > currentMoney then
            TriggerClientEvent("redemrp_notification:start",_source, "Invalid amount" , 2, "error")
@@ -63,7 +63,7 @@ end)
 RegisterServerEvent('redemrp_banking:balance2')
 AddEventHandler('redemrp_banking:balance2', function()
     local _source = source
-    TriggerEvent('redemrp:getPlayerFromId', source, function(user)
+    TriggerEvent('redemrp:getPlayerFromId', _source, function(user)
         local identifier = user.getIdentifier()
         local charid = user.getSessionVar("charid")
 		local namel = user.getLastname()


### PR DESCRIPTION
There were 3 instances of `_source` not being used in functions were it was declared.
This PR resolves that.